### PR TITLE
feat(telescope): add keybinding to find all files including ignored

### DIFF
--- a/lua/digia/plugin/telescope.lua
+++ b/lua/digia/plugin/telescope.lua
@@ -25,6 +25,7 @@ return {
     -- Files
     { "<leader>f/",  "<cmd>Telescope live_grep<cr>",                                desc = "Search Workspace" },
     { "<leader>fp",  "<cmd>Telescope find_files<cr>",                               desc = "Find Files" },
+    { "<leader>fP",  function() require("telescope.builtin").find_files({ find_command = { "rg", "--files", "--color", "never", "--no-ignore", "--hidden", "-g", "!.git" } }) end, desc = "Find All Files (inc. ignored)" },
     { "<leader>fg",  "<cmd>Telescope git_files<cr>",                                desc = "Find Files (git)" },
     { "<leader>fr",  "<cmd>Telescope oldfiles<cr>",                                 desc = "Recent Files" }, -- Previously opened files
 

--- a/lua/digia/plugin/telescope.lua
+++ b/lua/digia/plugin/telescope.lua
@@ -25,7 +25,7 @@ return {
     -- Files
     { "<leader>f/",  "<cmd>Telescope live_grep<cr>",                                desc = "Search Workspace" },
     { "<leader>fp",  "<cmd>Telescope find_files<cr>",                               desc = "Find Files" },
-    { "<leader>fP",  function() require("telescope.builtin").find_files({ find_command = { "rg", "--files", "--color", "never", "--no-ignore", "--hidden", "-g", "!.git" } }) end, desc = "Find All Files (inc. ignored)" },
+    { "<leader>fP",  function() require("telescope.builtin").find_files({ find_command = { "rg", "--files", "--color", "never", "--no-ignore", "--hidden", "-g", "!.git" } }) end, desc = "Find Files (All)" },
     { "<leader>fg",  "<cmd>Telescope git_files<cr>",                                desc = "Find Files (git)" },
     { "<leader>fr",  "<cmd>Telescope oldfiles<cr>",                                 desc = "Recent Files" }, -- Previously opened files
 


### PR DESCRIPTION
## Summary
- Added new keybinding `<leader>fP` to show all files in the project directory
- Includes files normally ignored by .gitignore (hidden files, build artifacts, dependencies)

## Implementation Details
- Uses ripgrep with `--no-ignore` and `--hidden` flags
- Still excludes .git directory contents with `-g \!.git`
- Positioned next to existing `<leader>fp` keybinding for easy discovery

## Test plan
- [x] Verified normal `<leader>fp` still respects .gitignore
- [x] Verified `<leader>fP` shows ignored files (tested with .env files)
- [x] Confirmed .git directory contents are still excluded
- [x] Tested that hidden files (dotfiles) are included

🤖 Generated with [Claude Code](https://claude.ai/code)